### PR TITLE
Just changing gorp repo url to new one

### DIFF
--- a/app/templates/_server.go
+++ b/app/templates/_server.go
@@ -9,7 +9,7 @@ import (
     "strings"
     "github.com/go-martini/martini"
     <% if (entities.length > 0) { %>"github.com/martini-contrib/binding"<% }; %>
-    "github.com/coopernurse/gorp"
+    "github.com/go-gorp/gorp"
 )
 
 // The one and only martini instance.

--- a/app/templates/models/_gorp.go
+++ b/app/templates/models/_gorp.go
@@ -8,7 +8,7 @@ import (
     "log"
     "reflect"
     "time"
-    "github.com/coopernurse/gorp"
+    "github.com/go-gorp/gorp"
     _ "github.com/mattn/go-sqlite3"
 )
 

--- a/entity/templates/routes/_entities.go
+++ b/entity/templates/routes/_entities.go
@@ -6,7 +6,7 @@ import (
     "net/http"
     "strconv"
     "github.com/go-martini/martini"
-    "github.com/coopernurse/gorp"
+    "github.com/go-gorp/gorp"
 )
 
 func Get<%= _.capitalize(pluralize(name)) %>(enc Encoder, db gorp.SqlExecutor) (int, string) {


### PR DESCRIPTION
Hi! I just saw that https://github.com/coopernurse/gorp/ has been moved to https://github.com/go-gorp/gorp.
I changed that in my angular-go-martini project (created with this generator), and it worked.

Regards,
Matías.
